### PR TITLE
Added error handler for AddressNotFoundException + allow IPv6

### DIFF
--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -244,7 +244,7 @@ class GeoIP {
 	 */
 	private function checkIp( $ip )
 	{
-                if ( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ) {
+                //if ( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ) {
                         $longip = ip2long($ip);
 
                         if ( !empty($ip) ) {
@@ -259,10 +259,10 @@ class GeoIP {
                                     }
                                     return true;
                         } 
-                }
-                elseif( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ) {
-                        return true;
-                }
+                //}
+                //elseif( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ) {
+                //        return true;
+                //}
 
 
 		return false;

--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -244,7 +244,7 @@ class GeoIP {
 	 */
 	private function checkIp( $ip )
 	{
-                //if ( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ) {
+                if ( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ) {
                         $longip = ip2long($ip);
 
                         if ( !empty($ip) ) {
@@ -259,10 +259,10 @@ class GeoIP {
                                     }
                                     return true;
                         } 
-                //}
-                //elseif( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ) {
-                //        return true;
-                //}
+                }
+                elseif( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ) {
+                        return true;
+                }
 
 
 		return false;

--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -244,20 +244,26 @@ class GeoIP {
 	 */
 	private function checkIp( $ip )
 	{
-		$longip = ip2long($ip);
+                if ( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ) {
+                        $longip = ip2long($ip);
 
-		if ( !empty($ip) ) {
+                        if ( !empty($ip) ) {
 
-			foreach ($this->reserved_ips as $r) {
-				$min = ip2long($r[0]);
-				$max = ip2long($r[1]);
+                                    foreach ($this->reserved_ips as $r) {
+                                            $min = ip2long($r[0]);
+                                            $max = ip2long($r[1]);
 
-				if ($longip >= $min && $longip <= $max) {
-					return false;
-				}
-			}
-			return true;
-		}
+                                            if ($longip >= $min && $longip <= $max) {
+                                                    return false;
+                                            }
+                                    }
+                                    return true;
+                        } 
+                }
+                elseif( filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ) {
+                        return true;
+                }
+
 
 		return false;
 	}


### PR DESCRIPTION
I noticed that when an IP is not in the maxmind database an error is thrown "GeoIp2\Exception\AddressNotFoundException".

Perhaps it's best to catch and log it directly?

Additionally allowed ipv6 IP's. City lookup does not work with ipv6 IP's, but country/timezone/continent do work.  