### PR TITLE
Database caching of MaxMind response, getLatLng() method, and minor clean-up of tabs/spaces

### DIFF
--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -215,7 +215,7 @@ class GeoIP {
 			
 			$location = GeoIPRecord::create([
 				"ip"          => $ip,
-				"isoCode"     => $record->country->isoCode,
+				"iso_code"    => $record->country->isoCode,
 				"country"     => $record->country->name,
 				"city"        => $record->city->name,
 				"state"       => $record->mostSpecificSubdivision->isoCode,

--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -181,11 +181,11 @@ class GeoIP {
 			// Get service name
 			$service = 'locate_'.$this->config->get('geoip.service');
 			
-		   // Check for valid service
-		   if (! method_exists($this, $service))
-		   {
+			// Check for valid service
+			if (! method_exists($this, $service))
+			{
 				throw new \Exception("GeoIP Service not supported or setup: " . $service);
-		   }
+			}
 			
 			return $this->$service($ip);
 		}
@@ -211,9 +211,9 @@ class GeoIP {
 		}
 		
 		try {
-		   $record = $maxmind->city($ip);
-		
-		   $location = GeoIPRecord::create([
+			$record = $maxmind->city($ip);
+			
+			$location = GeoIPRecord::create([
 				"ip"          => $ip,
 				"isoCode"     => $record->country->isoCode,
 				"country"     => $record->country->name,
@@ -225,17 +225,17 @@ class GeoIP {
 				"timezone"    => $record->location->timeZone,
 				"continent"   => $record->continent->code,
 				"default"     => false
-		   ]);
+			]);
 		}
 		catch (AddressNotFoundException $e)
 		{
-		   $location = GeoIPRecord::create($this->default_location);
+			$location = GeoIPRecord::create($this->default_location);
 			
-		   $logFile = 'geoip';
+			$logFile = 'geoip';
 			
-		   $log = new Logger($logFile);
-		   $log->pushHandler(new StreamHandler(storage_path()."/logs/{$logFile}.log", Logger::ERROR));
-		   $log->addError($e);
+			$log = new Logger($logFile);
+			$log->pushHandler(new StreamHandler(storage_path()."/logs/{$logFile}.log", Logger::ERROR));
+			$log->addError($e);
 		}
 		
 		unset($record);

--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -174,8 +174,14 @@ class GeoIP {
 		{
 			// Check the database
 			$record = GeoIPRecord::where('ip', '=', $ip)->take(1)->get()->first();
-			if( $record != null && strtotime($record->updated_at) > time() - 30 * 24 * 60 * 60 ) {
-				return $record;
+			if( $record != null ) {
+				if( strtotime($record->updated_at) > time() - 30 * 24 * 60 * 60 ) {
+					// Return cached record
+					return $record;
+				} else {
+					// Record too old... destroy it
+					$record->delete();
+				}
 			}
 			
 			// Get service name

--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -1,46 +1,55 @@
 <?php namespace Torann\GeoIP;
 
+use Torann\GeoIP\GeoIPRecord;
+
 use GeoIp2\Database\Reader;
+use GeoIp2\Exception\AddressNotFoundException;
 use GeoIp2\WebService\Client;
 
-use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
-
-use GeoIp2\Exception\AddressNotFoundException;
+use Monolog\Logger;
 
 use Illuminate\Config\Repository;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Session\Store as SessionStore;
 
 class GeoIP {
-
+	
 	/**
 	 * The session store.
 	 *
 	 * @var \Illuminate\Session\Store
 	 */
 	protected $session;
-
-    /**
-     * Illuminate config repository instance.
-     *
-     * @var \Illuminate\Config\Repository
-     */
-    protected $config;
-
+	
+	/**
+	* Illuminate config repository instance.
+	*
+	* @var \Illuminate\Config\Repository
+	*/
+	protected $config;
+	
+	/**
+	* Illuminate database manager instance.
+	*
+	* @var \Illuminate\Database\DatabaseManager
+	*/
+	protected $database;
+	
 	/**
 	 * Remote Machine IP address.
 	 *
 	 * @var float
 	 */
 	protected $remote_ip = null;
-
+	
 	/**
 	 * Location data.
 	 *
 	 * @var array
 	 */
 	protected $location = null;
-
+	
 	/**
 	 * Reserved IP address.
 	 *
@@ -56,82 +65,96 @@ class GeoIP {
 		array('192.168.0.0','192.168.255.255'),
 		array('255.255.255.0','255.255.255.255')
 	);
-
+	
 	/**
 	 * Default Location data.
 	 *
 	 * @var array
 	 */
 	protected $default_location = array (
-		"ip" 			=> "127.0.0.0",
-		"isoCode" 		=> "US",
-		"country" 		=> "United States",
-		"city" 			=> "New Haven",
-		"state" 		=> "CT",
-		"postal_code"   => "06510",
-		"lat" 			=> 41.31,
-		"lon" 			=> -72.92,
-		"timezone" 		=> "America/New_York",
-		"continent"		=> "NA",
-		"default"       => true
+		"ip"          => "127.0.0.0",
+		"isoCode"     => "US",
+		"country"     => "United States",
+		"city"        => "New Haven",
+		"state"       => "CT",
+		"postal_code" => "06510",
+		"lat"         => 41.31,
+		"lon"         => -72.92,
+		"timezone"    => "America/New_York",
+		"continent"   => "NA",
+		"default"     => true
 	);
-
+	
 	/**
 	 * Create a new GeoIP instance.
 	 *
-     * @param  \Illuminate\Config\Repository  $config
-	 * @param  \Illuminate\Session\Store      $session
+	 * @param  \Illuminate\Config\Repository         $config
+	 * @param  \Illuminate\Session\Store             $session
+	 * @param  \Illuminate\Database\DatabaseManager  $database
 	 */
-	public function __construct(Repository $config, SessionStore $session)
+	public function __construct(Repository $config, SessionStore $session, DatabaseManager $database)
 	{
-		$this->config  = $config;
-		$this->session = $session;
-
-        // Set custom default location
-        $this->default_location = array_merge(
-            $this->default_location,
-            $this->config->get('geoip.default_location', array())
-        );
-
-        // Set IP
+		$this->config   = $config;
+		$this->session  = $session;
+		$this->database = $database;
+		
+		// Set custom default location
+		$this->default_location = array_merge(
+			$this->default_location,
+			$this->config->get('geoip.default_location', array())
+		);
+		
+		// Set IP
 		$this->remote_ip = $this->default_location['ip'] = $this->getClientIP();
 	}
-
-	/**
-	 * Save location data in the session.
-	 *
-	 * @return void
-	 */
-	function saveLocation()
-    {
-		$this->session->set('geoip-location', $this->location);
-	}
-
+	
 	/**
 	 * Get location from IP.
 	 *
 	 * @param  string $ip Optional
 	 * @return array
 	 */
-	function getLocation($ip = null )
+	public function getLocation($ip = null)
 	{
 		// Get location data
 		$this->location = $this->find($ip);
-
+		
 		// Save user's location
 		if($ip === null) {
 			$this->saveLocation();
 		}
-
+		
 		return $this->location;
 	}
-
+	
+	/**
+	 * Get Lat/Lng as an array
+	 * 
+	 * @return array
+	 */
+	public function getLatLng($ip = null)
+	{
+		$this->getLocation($ip);
+		
+		return [$this->location['lat'], $this->location['lon']];
+	}
+	
+	/**
+	 * Save location data in the session.
+	 *
+	 * @return void
+	 */
+	private function saveLocation()
+	{
+		$this->session->set('geoip-location', $this->location);
+	}
+	
 	/**
 	 * Find location from IP.
 	 *
 	 * @param  string $ip Optional
 	 * @return array
-     * @throws \Exception
+	  * @throws \Exception
 	 */
 	private function find($ip = null)
 	{
@@ -140,30 +163,36 @@ class GeoIP {
 		{
 			return $position;
 		}
-
+		
 		// If IP not set, user remote IP
 		if ($ip === null) {
 			$ip = $this->remote_ip;
 		}
-
+		
 		// Check if the ip is not local or empty
 		if($this->checkIp($ip))
-        {
+		{
+			// Check the database
+			$record = GeoIPRecord::where('ip', '=', $ip)->take(1)->get()->first();
+			if( $record != null && strtotime($record->updated_at) > time() - 30 * 24 * 60 * 60 ) {
+				return $record;
+			}
+			
 			// Get service name
 			$service = 'locate_'.$this->config->get('geoip.service');
-
-            // Check for valid service
-            if (! method_exists($this, $service))
-            {
-                throw new \Exception("GeoIP Service not support or setup.");
-            }
-
+			
+		   // Check for valid service
+		   if (! method_exists($this, $service))
+		   {
+				throw new \Exception("GeoIP Service not supported or setup: " . $service);
+		   }
+			
 			return $this->$service($ip);
 		}
-
+		
 		return $this->default_location;
 	}
-
+	
 	/**
 	 * Maxmind Service.
 	 *
@@ -173,47 +202,47 @@ class GeoIP {
 	private function locate_maxmind($ip)
 	{
 		$settings = $this->config->get('geoip.maxmind');
-
+		
 		if($settings['type'] === 'web_service') {
 			$maxmind = new Client($settings['user_id'], $settings['license_key']);
 		}
 		else {
 			$maxmind = new Reader(base_path().'/database/maxmind/GeoLite2-City.mmdb');
 		}
-
-        try {
-            $record = $maxmind->city($ip);
-
-            $location = array(
-                "ip"			=> $ip,
-                "isoCode" 		=> $record->country->isoCode,
-                "country" 		=> $record->country->name,
-                "city" 			=> $record->city->name,
-                "state" 		=> $record->mostSpecificSubdivision->isoCode,
-                "postal_code"   => $record->postal->code,
-                "lat" 			=> $record->location->latitude,
-                "lon" 			=> $record->location->longitude,
-                "timezone" 		=> $record->location->timeZone,
-                "continent"		=> $record->continent->code,
-                "default"       => false
-            );
-        }
-        catch (AddressNotFoundException $e)
-        {
-            $location = $this->default_location;
-
-            $logFile = 'geoip';
-
-            $log = new Logger($logFile);
-            $log->pushHandler(new StreamHandler(storage_path()."/logs/{$logFile}.log", Logger::ERROR));
-            $log->addError($e);
-        }
-
-        unset($record);
-
-        return $location;
+		
+		try {
+		   $record = $maxmind->city($ip);
+		
+		   $location = GeoIPRecord::create([
+				"ip"          => $ip,
+				"isoCode"     => $record->country->isoCode,
+				"country"     => $record->country->name,
+				"city"        => $record->city->name,
+				"state"       => $record->mostSpecificSubdivision->isoCode,
+				"postal_code" => $record->postal->code,
+				"lat"         => $record->location->latitude,
+				"lon"         => $record->location->longitude,
+				"timezone"    => $record->location->timeZone,
+				"continent"   => $record->continent->code,
+				"default"     => false
+		   ]);
+		}
+		catch (AddressNotFoundException $e)
+		{
+		   $location = GeoIPRecord::create($this->default_location);
+			
+		   $logFile = 'geoip';
+			
+		   $log = new Logger($logFile);
+		   $log->pushHandler(new StreamHandler(storage_path()."/logs/{$logFile}.log", Logger::ERROR));
+		   $log->addError($e);
+		}
+		
+		unset($record);
+		
+		return $location;
 	}
-
+	
 	/**
 	 * Get the client IP address.
 	 *
@@ -245,10 +274,10 @@ class GeoIP {
 		else {
 			$ipaddress = '127.0.0.0';
 		}
-
+		
 		return $ipaddress;
 	}
-
+	
 	/**
 	 * Checks if the ip is not local or empty.
 	 *
@@ -256,33 +285,33 @@ class GeoIP {
 	 */
 	private function checkIp($ip)
 	{
-        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4))
-        {
-            $longip = ip2long($ip);
-
-            if (! empty($ip))
-            {
-                foreach ($this->reserved_ips as $r)
-                {
-                    $min = ip2long($r[0]);
-                    $max = ip2long($r[1]);
-
-                    if ($longip >= $min && $longip <= $max)
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-        }
-
-        else if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
-        {
-            return true;
-        }
-
-        return false;
+		if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4))
+		{
+			$longip = ip2long($ip);
+			
+			if (! empty($ip))
+			{
+				foreach ($this->reserved_ips as $r)
+				{
+					$min = ip2long($r[0]);
+					$max = ip2long($r[1]);
+					
+					if ($longip >= $min && $longip <= $max)
+					{
+						return false;
+					}
+				}
+				
+				return true;
+			}
+		}
+		
+		else if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+		{
+			return true;
+		}
+		
+		return false;
 	}
 
 }

--- a/src/Torann/GeoIP/GeoIPRecord.php
+++ b/src/Torann/GeoIP/GeoIPRecord.php
@@ -9,7 +9,7 @@ class GeoIPRecord extends Model {
 	 *
 	 * @var string
 	 */
-	protected $table = 'geoiprecords';
+	protected $table = 'geoip_records';
 	
 	/**
 	 * The attributes that are hidden from the return value.

--- a/src/Torann/GeoIP/GeoIPRecord.php
+++ b/src/Torann/GeoIP/GeoIPRecord.php
@@ -1,0 +1,28 @@
+<?php namespace Torann\GeoIP;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GeoIPRecord extends Model {
+	
+	/**
+	 * The database table used by the model.
+	 *
+	 * @var string
+	 */
+	protected $table = 'geoiprecords';
+	
+	/**
+	 * The attributes that are hidden from the return value.
+	 *
+	 * @var array
+	 */
+	protected $hidden = ['id', 'created_at', 'updated_at'];
+	
+	/**
+	 * The attributes that are mass assignable.
+	 *
+	 * @var array
+	 */
+	protected $fillable = ['ip', 'isoCode', 'country', 'city', 'state', 'postal_code', 'lat', 'lon', 'timezone', 'continent'];
+	
+}

--- a/src/Torann/GeoIP/GeoIPServiceProvider.php
+++ b/src/Torann/GeoIP/GeoIPServiceProvider.php
@@ -20,8 +20,11 @@ class GeoIPServiceProvider extends ServiceProvider {
 	{
 		$this->publishes([
 			__DIR__.'/../../config/geoip.php' => config_path('geoip.php'),
+		], 'config');
+		
+		$this->publishes([
 			__DIR__.'/../../migrations/' => base_path('/database/migrations'),
-		]);
+		], 'migrations');
 	}
 
 	/**

--- a/src/Torann/GeoIP/GeoIPServiceProvider.php
+++ b/src/Torann/GeoIP/GeoIPServiceProvider.php
@@ -20,11 +20,8 @@ class GeoIPServiceProvider extends ServiceProvider {
 	{
 		$this->publishes([
 			__DIR__.'/../../config/geoip.php' => config_path('geoip.php'),
-		], 'config');
-		
-		$this->publishes([
 			__DIR__.'/../../migrations/' => base_path('/database/migrations'),
-		], 'migrations');
+		]);
 	}
 
 	/**

--- a/src/Torann/GeoIP/GeoIPServiceProvider.php
+++ b/src/Torann/GeoIP/GeoIPServiceProvider.php
@@ -18,9 +18,13 @@ class GeoIPServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-        $this->publishes([
-            __DIR__.'/../../config/geoip.php' => config_path('geoip.php'),
-        ]);
+		$this->publishes([
+			__DIR__.'/../../config/geoip.php' => config_path('geoip.php'),
+		], 'config');
+		
+		$this->publishes([
+			__DIR__.'/../../migrations/' => base_path('/database/migrations'),
+		], 'migrations');
 	}
 
 	/**
@@ -33,7 +37,7 @@ class GeoIPServiceProvider extends ServiceProvider {
 		// Register providers.
 		$this->app['geoip'] = $this->app->share(function($app)
 		{
-			return new GeoIP($app['config'], $app["session.store"]);
+			return new GeoIP($app['config'], $app["session.store"], $app['db']);
 		});
 	}
 

--- a/src/migrations/2015_02_24_173301_create_geoiprecord_table.php
+++ b/src/migrations/2015_02_24_173301_create_geoiprecord_table.php
@@ -16,15 +16,15 @@ class CreateGeoiprecordTable extends Migration {
 		{
 			$table->increments('id');
 			$table->string('ip', 15)->unique();
-			$table->string('isoCode', 15);
-			$table->string('country', 30);
-			$table->string('city', 30);
-			$table->string('state', 30);
-			$table->string('postal_code', 15);
-			$table->double('lat');
-			$table->double('lon');
-			$table->string('timezone', 30);
-			$table->string('continent', 30);
+			$table->string('isoCode', 15)->nullable();
+			$table->string('country', 30)->nullable();
+			$table->string('city', 30)->nullable();
+			$table->string('state', 30)->nullable();
+			$table->string('postal_code', 15)->nullable();
+			$table->double('lat')->nullable();
+			$table->double('lon')->nullable();
+			$table->string('timezone', 30)->nullable();
+			$table->string('continent', 30)->nullable();
 			$table->boolean('default');
 			$table->timestamps();
 		});

--- a/src/migrations/2015_02_24_173301_create_geoiprecord_table.php
+++ b/src/migrations/2015_02_24_173301_create_geoiprecord_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateGeoiprecordTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('geoip_records', function(Blueprint $table)
+		{
+			$table->increments('id');
+			$table->string('ip', 15)->unique();
+			$table->string('isoCode', 15);
+			$table->string('country', 30);
+			$table->string('city', 30);
+			$table->string('state', 30);
+			$table->string('postal_code', 15);
+			$table->double('lat');
+			$table->double('lon');
+			$table->string('timezone', 30);
+			$table->string('continent', 30);
+			$table->boolean('default');
+			$table->timestamps();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop('geoip_records');
+	}
+
+}


### PR DESCRIPTION
 1. I added an Eloquent model (GeoIPRecord) which stores MaxMind responses. These are valid for 30 days. Optional enhancement in the future: setting this timespan in the config. The purpose of this is to reduce the number of calls made to MaxMind - if someone access the site from the same IP within 30 days and they have lost their session, it will simply pull their location from a local storage instead of burning through API query limits.

 2. I added a second public function: `getLatLng()`. This returns an array with just the latitude and longitude from the MaxMind response - useful if you plan to do any geography-related math or for working with the Google Maps API

 3. I converted spaces and tabs according to [Laravel's Coding Style guidelines](http://laravel.com/docs/5.0/contributions#coding-style) (indent with tabs, align with spaces)