### PR TITLE
Update GeoIP.php

### DIFF
--- a/src/Torann/GeoIP/GeoIP.php
+++ b/src/Torann/GeoIP/GeoIP.php
@@ -178,7 +178,7 @@ class GeoIP {
 			$maxmind = new Client($settings['user_id'], $settings['license_key']);
 		}
 		else {
-			$maxmind = new Reader(base_path().'/database/maxmind/GeoLite2-City.mmdb');
+			$maxmind = new Reader(base_path(). $settings['database']);
 		}
 
         try {


### PR DESCRIPTION
This update allows you to manually specify a MaxMind database in your .env. Just add  the path to MAXMIND_DB=
Ex: MAXMIND_DB=/database/maxmind/GeoIP2-City.mmdb

This allows you to use paid versions of the MaxMind DB.