### PR TITLE
Using the contract to inject the concrete class

### DIFF
--- a/src/Contracts/GeoIPInterface.php
+++ b/src/Contracts/GeoIPInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Torann\GeoIP\Contracts;
+
+interface GeoIPInterface
+{
+    /**
+     * Get the location from the provided IP.
+     *
+     * @param  string  $ip
+     *
+     * @return \Torann\GeoIP\Location
+     */
+    public function getLocation($ip = null);
+
+    /**
+     * Get the currency code from ISO.
+     *
+     * @param  string  $iso
+     *
+     * @return string
+     */
+    public function getCurrency($iso);
+
+    /**
+     * Get service instance.
+     *
+     * @return \Torann\GeoIP\Contracts\ServiceInterface
+     *
+     * @throws \Exception
+     */
+    public function getService();
+
+    /**
+     * Get cache instance.
+     *
+     * @return \Torann\GeoIP\Cache
+     */
+    public function getCache();
+
+    /**
+     * Get the client IP address.
+     *
+     * @return string
+     */
+    public function getClientIP();
+
+    /**
+     * Get configuration value.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     *
+     * @return mixed
+     */
+    public function config($key, $default = null);
+}

--- a/src/GeoIP.php
+++ b/src/GeoIP.php
@@ -7,8 +7,9 @@ use Monolog\Logger;
 use Illuminate\Support\Arr;
 use Illuminate\Cache\CacheManager;
 use Monolog\Handler\StreamHandler;
+use Torann\GeoIP\Contracts\GeoIPInterface;
 
-class GeoIP
+class GeoIP implements GeoIPInterface
 {
     /**
      * Illuminate config repository instance.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,19 +1,18 @@
 <?php
 
-if (!function_exists('geoip')) {
+if ( ! function_exists('geoip')) {
     /**
      * Get the location of the provided IP.
      *
-     * @param string $ip
+     * @param  string  $ip
      *
-     * @return \Torann\GeoIP\GeoIP|\Torann\GeoIP\Location
+     * @return \Torann\GeoIP\Contracts\GeoIPInterface|\Torann\GeoIP\Location
      */
     function geoip($ip = null)
     {
-        if (is_null($ip)) {
-            return app('geoip');
-        }
+        /** @var  Torann\GeoIP\Contracts\GeoIPInterface  $geoip */
+        $geoip = app(Torann\GeoIP\Contracts\GeoIPInterface::class);
 
-        return app('geoip')->getLocation($ip);
+        return is_null($ip) ? $geoip : $geoip->getLocation($ip);
     }
 }


### PR DESCRIPTION
ping @Torann 

#### DONE:

 * Registering the config file (you can use the package without publishing the config file => default settings).
 * Adding the `provides()` method.
 * Using Str class directly instead of the `str_*` helper.
 * Refactoring

#### Suggestions:

 * Making this package deferred ??

## Usage:

```php
<?php

namespace App\Http\Controllers;

use Torann\GeoIP\Contracts\GeoIPInterface;

class RandomController extends Controller
{
    /**
     * GeoIp instance.
     * 
     * @var \Torann\GeoIP\Contracts\GeoIPInterface
     */
    protected $geoip;

    /**
     * Constructor
     * 
     * @param  \Torann\GeoIP\Contracts\GeoIPInterface  $geoip
     */
    public function __construct(GeoIPInterface $geoip)
    {
        $this->geoip = $geoip;
    }

    /**
     * Search ip and do other stuff.
     * 
     * @param  string  $ip
     * 
     * @return mixed
     */
    public function search($ip)
    {
        $location = $this->geoip->getLocation($ip);

        // other stuff
    }
}
```