### PR TITLE
Add handle method in order to delegate to fire method for Laravel 5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea/*

--- a/src/Console/Clear.php
+++ b/src/Console/Clear.php
@@ -21,7 +21,17 @@ class Clear extends Command
     protected $description = 'Clear GeoIP cached locations.';
 
     /**
+     * Execute the console command for Laravel 5.5 and newer.
+     * @return void
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
      * Execute the console command.
+     * @return void
      */
     public function fire()
     {
@@ -40,7 +50,7 @@ class Clear extends Command
     protected function isSupported()
     {
         return empty(app('geoip')->config('cache_tags')) === false
-            && in_array(config('cache.default'), ['file', 'database']) === false;
+        && in_array(config('cache.default'), ['file', 'database']) === false;
     }
 
     /**

--- a/src/Console/Update.php
+++ b/src/Console/Update.php
@@ -21,6 +21,15 @@ class Update extends Command
     protected $description = 'Update GeoIP database files to the latest version';
 
     /**
+     * Execute the console command for Laravel 5.5 and newer.
+     * @return void
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -32,7 +41,7 @@ class Update extends Command
 
         // Ensure the selected service supports updating
         if (method_exists($service, 'update') === false) {
-            $this->info('The current service "' . get_class($service). '" does not support updating.');
+            $this->info('The current service "' . get_class($service) . '" does not support updating.');
             return;
         }
 
@@ -41,8 +50,7 @@ class Update extends Command
         // Perform update
         if ($result = $service->update()) {
             $this->info($result);
-        }
-        else {
+        } else {
             $this->error('Update failed!');
         }
     }


### PR DESCRIPTION
Laravel 5.5 would call for "handle" method on the console commands. The added "handle" methods would delegate to old "fire" methods.