### PR TITLE
Add support for Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
-    "illuminate/console": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
+    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*",
+    "illuminate/console": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",


### PR DESCRIPTION
The master branch no longer works with Laravel 5.6 after merging with #98, although it is fully compatible.