### PR TITLE
Add support for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*",
-    "illuminate/console": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*"
+    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+    "illuminate/console": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",


### PR DESCRIPTION
According to the [upgrade guide](https://laravel.com/docs/5.7/upgrade), there are no breaking changes that could affect this package, so the only change is updating the restriction in the Composer file.