### PR TITLE
Placing the country name correctly in ipdata.co

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
   "require": {
     "php": "^7.0",
     "illuminate/support": "~5.0",
-    "illuminate/console": "~5.0",
-    "vlucas/phpdotenv":"3.3"
+    "illuminate/console": "~5.0"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   "require": {
     "php": "^7.0",
     "illuminate/support": "~5.0",
-    "illuminate/console": "~5.0"
+    "illuminate/console": "~5.0",
+    "vlucas/phpdotenv":"3.3"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",

--- a/src/Services/IPData.php
+++ b/src/Services/IPData.php
@@ -53,7 +53,7 @@ class IPData extends AbstractService
         return $this->hydrate([
             'ip' => $ip,
             'iso_code' => $json['country_code'],
-            'country' => $json['continent_name'],
+            'country' => $json['country_name'],
             'city' => $json['city'],
             'state' => $json['region_code'],
             'state_name' => $json['region'],


### PR DESCRIPTION
In the service ipdata.co is currently putting the name of the continent in the name of the country.