### PR TITLE
Laravel 6.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --dev
 
-script: phpunit
+script: php ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
   ],
   "require": {
     "php": "^7.0",
-    "illuminate/support": "~5.0",
-    "illuminate/console": "~5.0",
+    "illuminate/support": "~5.0|^6.0",
+    "illuminate/console": "~5.0|^6.0",
     "vlucas/phpdotenv": "^3.5"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     }
   ],
   "require": {
-    "php": "^7.0",
-    "illuminate/support": "~5.0|^6.0",
-    "illuminate/console": "~5.0|^6.0",
+    "php": "^7.1",
+    "illuminate/support": "~5.5|^6.0",
+    "illuminate/console": "~5.5|^6.0",
     "vlucas/phpdotenv": "^3.5"
   },
   "suggest": {
@@ -29,7 +29,7 @@
     "monolog/monolog": "Allows for storing location not found errors to the log"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8",
+    "phpunit/phpunit": "^7.0",
     "mockery/mockery": "^0.9.4",
     "geoip2/geoip2": "~2.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   "require": {
     "php": "^7.0",
     "illuminate/support": "~5.0",
-    "illuminate/console": "~5.0"
+    "illuminate/console": "~5.0",
+    "vlucas/phpdotenv": "^3.5"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          verbose="true"
 >
     <testsuites>

--- a/src/GeoIPServiceProvider.php
+++ b/src/GeoIPServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Torann\GeoIP;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
 class GeoIPServiceProvider extends ServiceProvider
@@ -74,6 +75,6 @@ class GeoIPServiceProvider extends ServiceProvider
      */
     protected function isLumen()
     {
-        return str_contains($this->app->version(), 'Lumen') === true;
+        return Str::contains($this->app->version(), 'Lumen') === true;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,12 +9,12 @@ class TestCase extends PHPUnitTestCase
 {
     public static $functions;
 
-    public function setUp()
+    public function setUp(): void
     {
         self::$functions = Mockery::mock();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
Laravel 6.0 has now removed the deprecated string helper functions so I have replaced the one call I found with the class-based equivalent.

I was unable to run the tests without installing `phpdotenv` which is a `suggest` package for `illuminate\support`.

To be honest, I'm not 100% sure that these changes make the package 100% compatible with Laravel 6.0, however the tests in my project that touch this package are passing.