### PR TITLE
Fix IP-API Continents Update Command

### DIFF
--- a/src/Services/IPApi.php
+++ b/src/Services/IPApi.php
@@ -98,7 +98,7 @@ class IPApi extends AbstractService
      */
     public function update()
     {
-        $data = $this->client->get('http://dev.maxmind.com/static/csv/codes/country_continent.csv');
+        $data = $this->client->get('https://dev.maxmind.com/static/csv/codes/country_continent.csv');
 
         // Verify server response
         if ($this->client->getErrors() !== null) {


### PR DESCRIPTION
Maxmind updated the URL used to get the continents file, which broke the geoip:update command when using IP-API as the service. This simply fixes the URL to correctly populate the continents again.