### PR TITLE
Add location attributes as phpdoc class properties

### DIFF
--- a/src/Location.php
+++ b/src/Location.php
@@ -9,20 +9,20 @@ use Illuminate\Support\Arr;
 /**
  * Class Location
  *
- * @property string|null ip
- * @property string|null iso_code
- * @property string|null country
- * @property string|null city
- * @property string|null state
- * @property string|null state_name
- * @property string|null postal_code
- * @property float|null lat
- * @property float|null lon
- * @property string|null timezone
- * @property string|null continent
- * @property string|null currency
- * @property bool default
- * @property bool cached
+ * @property string|null $ip
+ * @property string|null $iso_code
+ * @property string|null $country
+ * @property string|null $city
+ * @property string|null $state
+ * @property string|null $state_name
+ * @property string|null $postal_code
+ * @property float|null $lat
+ * @property float|null $lon
+ * @property string|null $timezone
+ * @property string|null $continent
+ * @property string|null $currency
+ * @property bool $default
+ * @property bool $cached
  *
  * @package Torann\GeoIP
  */

--- a/src/Location.php
+++ b/src/Location.php
@@ -6,6 +6,26 @@ use ArrayAccess;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 
+/**
+ * Class Location
+ *
+ * @property string|null ip
+ * @property string|null iso_code
+ * @property string|null country
+ * @property string|null city
+ * @property string|null state
+ * @property string|null state_name
+ * @property string|null postal_code
+ * @property float|null lat
+ * @property float|null lon
+ * @property string|null timezone
+ * @property string|null continent
+ * @property string|null currency
+ * @property bool default
+ * @property bool cached
+ *
+ * @package Torann\GeoIP
+ */
 class Location implements ArrayAccess
 {
     /**


### PR DESCRIPTION
Hello,

I'm facing an issue where phpstorm complains fields are accessible through magic methods.

Fixing this means just adding some phpdoc class properties to the Location class to make phpstorm happy again :)