### PR TITLE
Update Maxmind database URL

### DIFF
--- a/config/geoip.php
+++ b/config/geoip.php
@@ -54,7 +54,7 @@ return [
         'maxmind_database' => [
             'class' => \Torann\GeoIP\Services\MaxMindDatabase::class,
             'database_path' => storage_path('app/geoip.mmdb'),
-            'update_url' => 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz',
+            'update_url' => sprintf('https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', env('MAXMIND_LICENSE_KEY')),
             'locales' => ['en'],
         ],
 
@@ -72,7 +72,7 @@ return [
             'continent_path' => storage_path('app/continents.json'),
             'lang' => 'en',
         ],
-        
+
         'ipgeolocation' => [
             'class' => \Torann\GeoIP\Services\IPGeoLocation::class,
             'secure' => true,


### PR DESCRIPTION
In relation to #162 this updates the default MaxMind database download URL (they now require you to register and use a licence key to get a copy). It's the same latest gzipped GeoLite2 City database and using the existing `MAXMIND_LICENSE_KEY` env variable.