### PR TITLE
Fix MaxMind database fetching

### DIFF
--- a/config/geoip.php
+++ b/config/geoip.php
@@ -54,7 +54,7 @@ return [
         'maxmind_database' => [
             'class' => \Torann\GeoIP\Services\MaxMindDatabase::class,
             'database_path' => storage_path('app/geoip.mmdb'),
-            'update_url' => 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz',
+            'update_url' => sprintf('https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', env('MAXMIND_LICENSE_KEY')),
             'locales' => ['en'],
         ],
 
@@ -72,7 +72,7 @@ return [
             'continent_path' => storage_path('app/continents.json'),
             'lang' => 'en',
         ],
-        
+
         'ipgeolocation' => [
             'class' => \Torann\GeoIP\Services\IPGeoLocation::class,
             'secure' => true,

--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -131,6 +131,8 @@ class MaxMindDatabase extends AbstractService
                 return $file;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -2,6 +2,7 @@
 
 namespace Torann\GeoIP\Services;
 
+use PharData;
 use Exception;
 use GeoIp2\Database\Reader;
 
@@ -66,27 +67,98 @@ class MaxMindDatabase extends AbstractService
             throw new Exception('Database path not set in config file.');
         }
 
-        // Get settings
-        $url = $this->config('update_url');
-        $path = $this->config('database_path');
+        $this->withTemporaryDirectory(function ($directory) {
+            $tarFile = sprintf('%s/maxmind.tar.gz', $directory);
 
-        // Get header response
-        $headers = get_headers($url);
+            file_put_contents($tarFile, fopen($this->config('update_url'), 'r'));
 
-        if (substr($headers[0], 9, 3) != '200') {
-            throw new Exception('Unable to download database. (' . substr($headers[0], 13) . ')');
+            $archive = new PharData($tarFile);
+
+            $file = $this->findDatabaseFile($archive);
+
+            if (is_null($file)) {
+                throw new Exception('Database file could not be found within archive.');
+            }
+
+            $relativePath = "{$archive->getFilename()}/{$file->getFilename()}";
+
+            $archive->extractTo($directory, $relativePath);
+
+            file_put_contents($this->config('database_path'), fopen("{$directory}/{$relativePath}", 'r'));
+        });
+
+        return "Database file ({$this->config('database_path')}) updated.";
+    }
+
+    /**
+     * Provide a temporary directory to perform operations in and and ensure
+     * it is removed afterwards.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    protected function withTemporaryDirectory(callable $callback)
+    {
+        $directory = tempnam(sys_get_temp_dir(), 'maxmind');
+
+        if (file_exists($directory)) {
+            unlink($directory);
         }
 
-        // Download zipped database to a system temp file
-        $tmpFile = tempnam(sys_get_temp_dir(), 'maxmind');
-        file_put_contents($tmpFile, fopen($url, 'r'));
+        mkdir($directory);
 
-        // Unzip and save database
-        file_put_contents($path, gzopen($tmpFile, 'r'));
+        try {
+            $callback($directory);
+        } finally {
+            $this->deleteDirectory($directory);
+        }
+    }
 
-        // Remove temp file
-        @unlink($tmpFile);
+    /**
+     * Recursively search the given archive to find the .mmdb file.
+     *
+     * @param  \PharData  $archive
+     * @return mixed
+     */
+    protected function findDatabaseFile($archive)
+    {
+        foreach ($archive as $file) {
+            if ($file->isDir()) {
+                return $this->findDatabaseFile(new PharData($file->getPathName()));
+            }
 
-        return "Database file ({$path}) updated.";
+            if (pathinfo($file, PATHINFO_EXTENSION) === 'mmdb') {
+                return $file;
+            }
+        }
+    }
+
+    /**
+     * Recursively delete the given directory.
+     *
+     * @param  string  $directory
+     * @return mixed
+     */
+    protected function deleteDirectory(string $directory)
+    {
+        if (!file_exists($directory)) {
+            return true;
+        }
+
+        if (!is_dir($directory)) {
+            return unlink($directory);
+        }
+
+        foreach (scandir($directory) as $item) {
+            if ($item == '.' || $item == '..') {
+                continue;
+            }
+
+            if (!$this->deleteDirectory($directory . DIRECTORY_SEPARATOR . $item)) {
+                return false;
+            }
+        }
+
+        return rmdir($directory);
     }
 }

--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -76,10 +76,6 @@ class MaxMindDatabase extends AbstractService
 
             $file = $this->findDatabaseFile($archive);
 
-            if (is_null($file)) {
-                throw new Exception('Database file could not be found within archive.');
-            }
-
             $relativePath = "{$archive->getFilename()}/{$file->getFilename()}";
 
             $archive->extractTo($directory, $relativePath);
@@ -119,6 +115,7 @@ class MaxMindDatabase extends AbstractService
      *
      * @param  \PharData  $archive
      * @return mixed
+     * @throws \Exception
      */
     protected function findDatabaseFile($archive)
     {
@@ -132,7 +129,7 @@ class MaxMindDatabase extends AbstractService
             }
         }
 
-        return null;
+        throw new Exception('Database file could not be found within archive.');
     }
 
     /**

--- a/tests/Services/MaxMindDatabaseTest.php
+++ b/tests/Services/MaxMindDatabaseTest.php
@@ -46,18 +46,6 @@ class MaxMindDatabaseTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function shouldUpdateLocalDatabase()
-    {
-        list($service, $config) = $this->getService();
-
-        $this->assertEquals($service->update(), "Database file ({$config['database_path']}) updated.");
-
-        @unlink($config['database_path']);
-    }
-
     protected function getService()
     {
         $config = $this->getConfig()['services']['maxmind_database'];


### PR DESCRIPTION
This is a follow-up to #163 that is intended to fix #162.

It expands on the work by @tylermann - with a couple of differences.

Instead of adding the database filename to the config it searches for the first file with the extension `.mmdb` and assumes this is the correct one. Seems like a little simpler to me though less configurable - open to feedback here.

It would be great if we could leverage Laravel's filesystem adapter as it would clean up much of the directory creation/removal code, but that's probably part of a larger discussion.