### PR TITLE
Move phpdotenv to require-dev in composer.json to allow installations on Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
   "require": {
     "php": "^7.1",
     "illuminate/support": "~5.5|^6.0",
-    "illuminate/console": "~5.5|^6.0",
-    "vlucas/phpdotenv": "^3.5"
+    "illuminate/console": "~5.5|^6.0"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",
@@ -31,7 +30,8 @@
   "require-dev": {
     "phpunit/phpunit": "^7.0",
     "mockery/mockery": "^0.9.4",
-    "geoip2/geoip2": "~2.1"
+    "geoip2/geoip2": "~2.1",
+    "vlucas/phpdotenv": "^3.5"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
This commit introduced the dependency https://github.com/Torann/laravel-geoip/commit/8f3b596964155fc707be5fdb9022612b87f18c0f and if it's a dev dependency I think it should be moved to required-dev section. The commit message says it's needed for unit tests.

Otherwise can't seem to install this package on Laravel 5.8 as it is locked to ^3.3 version for phpdotenv
https://github.com/laravel/framework/blob/5.8/composer.json#L43

Composer require throws this:
```
  Problem 1
    - Installation request for torann/geoip ^1.1 -> satisfiable by torann/geoip[1.1.0].
    - Conclusion: remove vlucas/phpdotenv v3.4.0
    - Conclusion: don't install vlucas/phpdotenv v3.4.0
    - torann/geoip 1.1.0 requires vlucas/phpdotenv ^3.5 -> satisfiable by vlucas/phpdotenv[v3.5.0, v3.6.0].
    - Can only install one of: vlucas/phpdotenv[v3.5.0, v3.4.0].
    - Can only install one of: vlucas/phpdotenv[v3.6.0, v3.4.0].
    - Installation request for vlucas/phpdotenv (locked at v3.4.0) -> satisfiable by vlucas/phpdotenv[v3.4.0].
```