### PR TITLE
Support for Laravel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "description": "Support for multiple GeoIP services.",
   "keywords": [
     "laravel",
-    "laravel 5",
+    "laravel 6",
+    "laravel 7",
     "geoip",
     "location",
     "geolocation",
@@ -19,17 +20,17 @@
     }
   ],
   "require": {
-    "php": "^7.1",
-    "illuminate/support": "~5.5|^6.0",
-    "illuminate/console": "~5.5|^6.0"
+    "php": "^7.2",
+    "illuminate/support": "^6.0|^7.0",
+    "illuminate/console": "^6.0|^7.0"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",
     "monolog/monolog": "Allows for storing location not found errors to the log"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
-    "mockery/mockery": "^0.9.4",
+    "phpunit/phpunit": "^8.0",
+    "mockery/mockery": "^1.3",
     "geoip2/geoip2": "~2.1",
     "vlucas/phpdotenv": "^3.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,6 @@
   "description": "Support for multiple GeoIP services.",
   "keywords": [
     "laravel",
-    "laravel 6",
-    "laravel 7",
     "geoip",
     "location",
     "geolocation",


### PR DESCRIPTION
Also some opinionated removal of PHP 7.1 and Laravel 5.5 support. The current version that supports Laravel 5.5 is stable and working, so let's move forward.