### PR TITLE
Remove faulty mkdir call

### DIFF
--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -26,7 +26,6 @@ class MaxMindDatabase extends AbstractService
 
         // Copy test database for now
         if (is_file($path) === false) {
-            mkdir(str_replace('/geoip.mmdb', '', $path));
             copy(__DIR__ . '/../../resources/geoip.mmdb', $path);
         }
 


### PR DESCRIPTION
This reverts a change that was made in #172 

Quoting my comment from that PR:

> This update has broken MaxMindDatabase for me.
> 
> [2020-03-09 23:23:40] testing.ERROR: mkdir(): File exists {"exception":"[object] (ErrorException(code: 0): mkdir(): File exists at /Users/Dwight/Sites/my-app/vendor/torann/geoip/src/Services/MaxMindDatabase.php:29)
> This is with the default configuration. Out of the box the path is storage/app/geoip.mmdb, your call to str_replace turns this into storage/app and then tries to create that directory, which already exists.
> 
> This PR should be reverted, and made again if necessary with a proper explanation of the error that is being seen and relevant tests to ensure it isn't breaking existing functionality.

The change means the latest release has started breaking test suites. I don't believe the original PR describes well enough what it was trying to fix, so rather than attempting to resolve that issue I suggest we revert it and ship a patch release.