### PR TITLE
PHP 8.0 - Enable in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "illuminate/support": "^8.0",
     "illuminate/console": "^8.0",
     "illuminate/cache": "^8.0"


### PR DESCRIPTION
I adjusted the "php" requirement in composer.json to "". 

All tests pass. Can this get merged so we can use this project with PHP 8? 