### PR TITLE
support for laravel 7 running on php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
   ],
   "require": {
     "php": "^7.2 || ^8.0",
-    "illuminate/support": "^8.0",
-    "illuminate/console": "^8.0",
-    "illuminate/cache": "^8.0"
+    "illuminate/support": "^7.0|^8.0",
+    "illuminate/console": "^7.0|^8.0",
+    "illuminate/cache": "^7.0|^8.0"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",


### PR DESCRIPTION
sets illuminate/* to support laravel 7, not only laravel 8