### PR TITLE
Allow dependency injection

### DIFF
--- a/src/Console/Clear.php
+++ b/src/Console/Clear.php
@@ -3,6 +3,7 @@
 namespace Torann\GeoIP\Console;
 
 use Illuminate\Console\Command;
+use Torann\GeoIP\GeoIP;
 
 class Clear extends Command
 {
@@ -51,7 +52,7 @@ class Clear extends Command
      */
     protected function isSupported()
     {
-        return empty(app('geoip')->config('cache_tags')) === false
+        return empty(app(GeoIP::class)->config('cache_tags')) === false
             && in_array(config('cache.default'), ['file', 'database']) === false;
     }
 
@@ -64,7 +65,7 @@ class Clear extends Command
     {
         $this->output->write("Clearing cache...");
 
-        app('geoip')->getCache()->flush();
+        app(GeoIP::class)->getCache()->flush();
 
         $this->output->writeln("<info>complete</info>");
     }

--- a/src/Console/Update.php
+++ b/src/Console/Update.php
@@ -3,6 +3,7 @@
 namespace Torann\GeoIP\Console;
 
 use Illuminate\Console\Command;
+use Torann\GeoIP\GeoIP;
 
 class Update extends Command
 {
@@ -38,7 +39,7 @@ class Update extends Command
     public function fire()
     {
         // Get default service
-        $service = app('geoip')->getService();
+        $service = app(GeoIP::class)->getService();
 
         // Ensure the selected service supports updating
         if (method_exists($service, 'update') === false) {

--- a/src/GeoIPServiceProvider.php
+++ b/src/GeoIPServiceProvider.php
@@ -33,7 +33,7 @@ class GeoIPServiceProvider extends ServiceProvider
      */
     public function registerGeoIpService()
     {
-        $this->app->singleton('geoip', function ($app) {
+        $this->app->singleton(GeoIP::class, function ($app) {
             return new GeoIP(
                 $app->config->get('geoip', []),
                 $app['cache']

--- a/src/GeoIPServiceProvider.php
+++ b/src/GeoIPServiceProvider.php
@@ -2,10 +2,11 @@
 
 namespace Torann\GeoIP;
 
-use Illuminate\Support\Str;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
-class GeoIPServiceProvider extends ServiceProvider
+class GeoIPServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     /**
      * Register the service provider.
@@ -39,6 +40,16 @@ class GeoIPServiceProvider extends ServiceProvider
                 $app['cache']
             );
         });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [GeoIP::class];
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,8 @@
 <?php
 
-if (!function_exists('geoip')) {
+use Torann\GeoIP\GeoIP;
+
+if (!function_exists(GeoIP::class)) {
     /**
      * Get the location of the provided IP.
      *
@@ -11,9 +13,9 @@ if (!function_exists('geoip')) {
     function geoip($ip = null)
     {
         if (is_null($ip)) {
-            return app('geoip');
+            return app(GeoIP::class);
         }
 
-        return app('geoip')->getLocation($ip);
+        return app(GeoIP::class)->getLocation($ip);
     }
 }


### PR DESCRIPTION
Allow dependency injection. To avoid using a global variable.

```php
    use Torann\GeoIP\GeoIP;

    public function login(GeoIP $geoip)
    {
        return $geoip->getLocation($request->ip())->toArray();
    }
```