### PR TITLE
Support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^8.0|^8.1",
+    "php": "^8.0",
     "illuminate/support": "^8.0",
     "illuminate/console": "^8.0",
     "illuminate/cache": "^8.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0",
+    "php": "^8.0|^8.1",
     "illuminate/support": "^8.0",
     "illuminate/console": "^8.0",
     "illuminate/cache": "^8.0"

--- a/src/Location.php
+++ b/src/Location.php
@@ -154,7 +154,7 @@ class Location implements ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->$offset);
     }
@@ -166,7 +166,7 @@ class Location implements ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->$offset;
     }
@@ -179,7 +179,7 @@ class Location implements ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->$offset = $value;
     }
@@ -191,7 +191,7 @@ class Location implements ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->$offset);
     }


### PR DESCRIPTION
Fixes: https://github.com/Torann/laravel-geoip/issues/209

It also changes minimal PHP version to PHP 8.0 (active support of PHP 7.4 finished 12 days ago)

![image](https://user-images.githubusercontent.com/5278175/145570901-c50130c5-2223-499e-8dce-f36a889ec82c.png)


