### PR TITLE
Allow installation with Laravel 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
   ],
   "require": {
     "php": "^8.0",
-    "illuminate/support": "^8.0",
-    "illuminate/console": "^8.0",
-    "illuminate/cache": "^8.0"
+    "illuminate/cache": "^8.0|^9.0",
+    "illuminate/console": "^8.0|^9.0",
+    "illuminate/support": "^8.0|^9.0"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",


### PR DESCRIPTION
This allows the package to be installed with Laravel 9.x (due to be released tomorrow).

I also ordered the Illuminate dependencies alphabetically 🤌