### PR TITLE
fix: temporary fix openssl issue on some machine

### DIFF
--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -73,7 +73,7 @@ class MaxMindDatabase extends AbstractService
         $this->withTemporaryDirectory(function ($directory) {
             $tarFile = sprintf('%s/maxmind.tar.gz', $directory);
 
-            file_put_contents($tarFile, fopen($this->config('update_url'), 'r'));
+            @file_put_contents($tarFile, fopen($this->config('update_url'), 'r'));
 
             $archive = new PharData($tarFile);
 


### PR DESCRIPTION
Hello,

Php currently have an issue with openssl https://github.com/php/php-src/issues/8369,

For some machine, `file_get_contents` and `file_put_contents` will fail, we could fix it with this approach  https://github.com/guzzle/psr7/issues/504#issuecomment-1114693965, but I think it overkill for a simple database update command.

I'll revert this commit sometime in the future when php got fix.