### PR TITLE
Support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.0|^8.1",
     "illuminate/cache": "^8.0|^9.0",
     "illuminate/console": "^8.0|^9.0",
     "illuminate/support": "^8.0|^9.0"


### PR DESCRIPTION
Currently it is not possible to install the package via Composer and PHP 8.1 in place. This PR aims to enable support for PHP 8.1.