### PR TITLE
Update config geoip.php, update cache_expires comment

### DIFF
--- a/config/geoip.php
+++ b/config/geoip.php
@@ -131,7 +131,7 @@ return [
     | Cache Expiration
     |--------------------------------------------------------------------------
     |
-    | Define how long cached location are valid.
+    | Define how long the cached location is valid (in seconds).
     |
     */
 


### PR DESCRIPTION
Make it clearer that the number is in seconds.
I didn't know before until I tested it manually. By adding this comment, it will help others quickly understand how long the expiration cache works.