### PR TITLE
Won't show exception if cache driver is not supported

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -29,7 +29,7 @@ class Cache
      */
     public function __construct(CacheManager $cache, $tags, $expires = 30)
     {
-        $this->cache = $tags ? $cache->tags($tags) : $cache;
+        $this->cache = $tags && ! in_array($cache->getDefaultDriver(), ['file', 'database']) ? $cache->tags($tags) : $cache;
         $this->expires = $expires;
     }
 


### PR DESCRIPTION
Instead of throwing an exception, the configuration file explicitly mentioned the unsupported drivers, the package should gracefully handle it instead of throwing an exception.