### PR TITLE
Update for Laravel 11 compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     }
   ],
   "require": {
-    "php": "^8.0|^8.1",
+    "php": "^8.0|^8.1|^8.2",
     "illuminate/cache": "^8.0|^9.0|^10.0",
     "illuminate/console": "^8.0|^9.0|^10.0",
-    "illuminate/support": "^8.0|^9.0|^10.0"
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
   },
   "suggest": {
     "geoip2/geoip2": "Required to use the MaxMind database or web service with GeoIP (~2.1).",
     "monolog/monolog": "Allows for storing location not found errors to the log"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0|^9.0|^10.0",
+    "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0",
     "mockery/mockery": "^1.3",
     "geoip2/geoip2": "~2.1",
     "vlucas/phpdotenv": "^5.0",


### PR DESCRIPTION
The composer.json file has been updated to allow newer versions of PHP and specific packages. PHP is now supported up to 8.2, Illuminate/support up to 11.0, and PHPUnit/phpunit up to 11.0. This change allows upgrade to Laravel 11