### PR TITLE
MaxMind's localizations based on config

### DIFF
--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -2,6 +2,8 @@
 
 namespace Torann\GeoIP\Services;
 
+use GeoIp2\Model\City;
+use Illuminate\Support\Arr;
 use PharData;
 use Exception;
 use GeoIp2\Database\Reader;
@@ -55,7 +57,27 @@ class MaxMindDatabase extends AbstractService
             'lon' => $record->location->longitude,
             'timezone' => $record->location->timeZone,
             'continent' => $record->continent->code,
+            'localizations' => $this->getLocallizations($record),
         ]);
+    }
+
+    /**
+     * Get localized country name, state name and city name based on config languages
+     *
+     * @param City $record
+     * @return array
+     */
+    private function getLocallizations(City $record)
+    {
+        $locales = [];
+
+        foreach ($this->config('locales') as $lang) {
+            $locales[$lang]['country'] = Arr::get($record->country->names, $lang);
+            $locales[$lang]['state_name'] = Arr::get($record->mostSpecificSubdivision->names, $lang);
+            $locales[$lang]['city'] = Arr::get($record->city->names, $lang);
+        }
+
+        return $locales;
     }
 
     /**

--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -69,15 +69,15 @@ class MaxMindDatabase extends AbstractService
      */
     private function getLocallizations(City $record)
     {
-        $locales = [];
+        $localizations = [];
 
-        foreach ($this->config('locales') as $lang) {
-            $locales[$lang]['country'] = Arr::get($record->country->names, $lang);
-            $locales[$lang]['state_name'] = Arr::get($record->mostSpecificSubdivision->names, $lang);
-            $locales[$lang]['city'] = Arr::get($record->city->names, $lang);
+        foreach ($this->config('locales', ['en']) as $lang) {
+            $localizations[$lang]['country'] = Arr::get($record->country->names, $lang);
+            $localizations[$lang]['state_name'] = Arr::get($record->mostSpecificSubdivision->names, $lang);
+            $localizations[$lang]['city'] = Arr::get($record->city->names, $lang);
         }
 
-        return $locales;
+        return $localizations;
     }
 
     /**

--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -57,7 +57,7 @@ class MaxMindDatabase extends AbstractService
             'lon' => $record->location->longitude,
             'timezone' => $record->location->timeZone,
             'continent' => $record->continent->code,
-            'localizations' => $this->getLocallizations($record),
+            'localizations' => $this->getLocalizations($record),
         ]);
     }
 
@@ -67,7 +67,7 @@ class MaxMindDatabase extends AbstractService
      * @param City $record
      * @return array
      */
-    private function getLocallizations(City $record)
+    private function getLocalizations(City $record): array
     {
         $localizations = [];
 

--- a/src/Services/MaxMindWebService.php
+++ b/src/Services/MaxMindWebService.php
@@ -2,7 +2,9 @@
 
 namespace Torann\GeoIP\Services;
 
+use GeoIp2\Model\City;
 use GeoIp2\WebService\Client;
+use Illuminate\Support\Arr;
 
 class MaxMindWebService extends AbstractService
 {
@@ -46,6 +48,26 @@ class MaxMindWebService extends AbstractService
             'lon' => $record->location->longitude,
             'timezone' => $record->location->timeZone,
             'continent' => $record->continent->code,
+            'localizations' => $this->getLocallizations($record),
         ]);
+    }
+
+    /**
+     * Get localized country name, state name and city name based on config languages
+     *
+     * @param City $record
+     * @return array
+     */
+    private function getLocallizations(City $record)
+    {
+        $locales = [];
+
+        foreach ($this->config('locales') as $lang) {
+            $locales[$lang]['country'] = Arr::get($record->country->names, $lang);
+            $locales[$lang]['state_name'] = Arr::get($record->mostSpecificSubdivision->names, $lang);
+            $locales[$lang]['city'] = Arr::get($record->city->names, $lang);
+        }
+
+        return $locales;
     }
 }

--- a/src/Services/MaxMindWebService.php
+++ b/src/Services/MaxMindWebService.php
@@ -60,14 +60,14 @@ class MaxMindWebService extends AbstractService
      */
     private function getLocallizations(City $record)
     {
-        $locales = [];
+        $localizations = [];
 
-        foreach ($this->config('locales') as $lang) {
-            $locales[$lang]['country'] = Arr::get($record->country->names, $lang);
-            $locales[$lang]['state_name'] = Arr::get($record->mostSpecificSubdivision->names, $lang);
-            $locales[$lang]['city'] = Arr::get($record->city->names, $lang);
+        foreach ($this->config('locales', ['en']) as $lang) {
+            $localizations[$lang]['country'] = Arr::get($record->country->names, $lang);
+            $localizations[$lang]['state_name'] = Arr::get($record->mostSpecificSubdivision->names, $lang);
+            $localizations[$lang]['city'] = Arr::get($record->city->names, $lang);
         }
 
-        return $locales;
+        return $localizations;
     }
 }

--- a/src/Services/MaxMindWebService.php
+++ b/src/Services/MaxMindWebService.php
@@ -48,7 +48,7 @@ class MaxMindWebService extends AbstractService
             'lon' => $record->location->longitude,
             'timezone' => $record->location->timeZone,
             'continent' => $record->continent->code,
-            'localizations' => $this->getLocallizations($record),
+            'localizations' => $this->getLocalizations($record),
         ]);
     }
 
@@ -58,7 +58,7 @@ class MaxMindWebService extends AbstractService
      * @param City $record
      * @return array
      */
-    private function getLocallizations(City $record)
+    private function getLocalizations(City $record): array
     {
         $localizations = [];
 


### PR DESCRIPTION
Currently, the result of obtaining a location only works with one language, despite the fact that it is possible to specify several languages in the configuration file. My changes allow to add several localizations for MaxMind (unfortunately I can’t implement it for other services, because I don’t have the keys) to the returned result, when specifying several languages: `'locales' => ['en', 'ru', 'pl']`. The returned result will be:
```
[
  "ip" => "37.212.55.000"
  "iso_code" => "BY"
  "country" => "Belarus"
  "city" => "Vertelishki"
  "state" => "HR"
  "state_name" => "Grodnenskaya"
  "postal_code" => "231751"
  "lat" => 53.7041
  "lon" => 24.0152
  "timezone" => "Europe/Minsk"
  "continent" => "EU"
  "localizations" => [
    "en" => [
      "country" => "Belarus"
      "state_name" => "Grodnenskaya"
      "city" => "Vertelishki"
    ]
    "ru" => [
      "country" => "Беларусь"
      "state_name" => "Гродненская Область"
      "city" => "Вертелишки"
    ]
    "pl" => [
      "country" => null
      "state_name" => null
      "city" => null
    ]
  ]
  "currency" => "BYN"
  "default" => false
]
```