### PR TITLE
Add ip2geo service driver

### DIFF
--- a/config/geoip.php
+++ b/config/geoip.php
@@ -84,6 +84,11 @@ return [
             'locales' => ['en'],
         ],
 
+        'ip2geo' => [
+            'class' => \Torann\GeoIP\Services\IP2Geo::class,
+            'key' => env('IP2GEO_API_KEY'),
+        ],
+
     ],
 
     /*

--- a/src/Services/IP2Geo.php
+++ b/src/Services/IP2Geo.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Torann\GeoIP\Services;
+
+use Exception;
+use Illuminate\Support\Arr;
+use Torann\GeoIP\Support\HttpClient;
+
+class IP2Geo extends AbstractService
+{
+    /**
+     * Http client instance.
+     *
+     * @var HttpClient
+     */
+    protected $client;
+
+    /**
+     * The "booting" method of the service.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->client = new HttpClient([
+            'base_uri' => 'https://api.ip2geo.dev/',
+            'headers' => [
+                'User-Agent: Laravel-GeoIP',
+                'X-Api-Key: ' . $this->config('key'),
+            ],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws Exception
+     */
+    public function locate($ip)
+    {
+        // Get data from client
+        $data = $this->client->get('convert', ['ip' => $ip]);
+
+        // Verify server response
+        if ($this->client->getErrors() !== null) {
+            throw new Exception('Request failed (' . $this->client->getErrors() . ')');
+        }
+
+        // Parse body content
+        $json = json_decode($data[0], true);
+
+        // Verify response status
+        if (empty($json) || !Arr::get($json, 'success')) {
+            throw new Exception('Request failed (' . Arr::get($json, 'message', 'Unknown error') . ')');
+        }
+
+        $data = Arr::get($json, 'data', []);
+
+        $continent = Arr::get($data, 'continent', []);
+        $country = Arr::get($continent, 'country', []);
+        $city = Arr::get($country, 'city', []);
+        $subdivision = Arr::get($country, 'subdivision', []);
+        $timezone = Arr::get($city, 'timezone', []);
+        $currency = Arr::get($country, 'currency', []);
+
+        return $this->hydrate([
+            'ip' => $ip,
+            'iso_code' => Arr::get($country, 'code'),
+            'country' => Arr::get($country, 'name'),
+            'city' => Arr::get($city, 'name'),
+            'state' => Arr::get($subdivision, 'code'),
+            'state_name' => Arr::get($subdivision, 'name'),
+            'postal_code' => Arr::get($city, 'postal_code'),
+            'lat' => Arr::get($city, 'latitude'),
+            'lon' => Arr::get($city, 'longitude'),
+            'timezone' => Arr::get($timezone, 'name'),
+            'continent' => Arr::get($continent, 'code'),
+            'currency' => Arr::get($currency, 'code'),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new service driver for the [ip2geo](https://ip2geo.dev) IP geolocation API.

- Supports IPv4 and IPv6 address lookup
- Returns all standard Location fields: city, country, state, lat/lon, timezone, continent, currency, postal code
- Authentication via `X-Api-Key` header
- Free tier available at [ip2geo.dev](https://ip2geo.dev)

## Configuration

```php
// config/geoip.php
'service' => 'ip2geo',

'services' => [
    'ip2geo' => [
        'class' => \Torann\GeoIP\Services\IP2Geo::class,
        'key' => env('IP2GEO_API_KEY'),
    ],
]
```

## Files changed

- **New:** `src/Services/IP2Geo.php` — driver implementation
- **Modified:** `config/geoip.php` — added ip2geo config entry

## Test plan

- [x] `php -l` syntax check passes
- [x] Live API: `locate('134.201.250.155')` returns correct Location (Los Angeles, CA, 34.0544, -118.244, USD)
- [x] Bad API key properly throws Exception
- [x] All Location fields populated correctly (ip, city, state, country, iso_code, lat, lon, timezone, continent, currency, postal_code)